### PR TITLE
VIX-3419 Initial restructure of the action flow

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -20,7 +20,7 @@ jobs:
 
   setup:
   
-    if: github.repository == 'VixenLights/Vixen'
+    if: github.repository == 'VixenLights/Vixen' || github.repository == 'jeffu231/Vixen'
   
     runs-on: windows-2019
 
@@ -31,15 +31,18 @@ jobs:
       pre_release: ${{ env.VIX_PRE_RELEASE }}
       release_tag: ${{ env.VIX_RELEASE_TAG }}
       version: ${{ env.VIX_VERSION }}
+      app_version: ${{ env.VIX_APP_VERSION }}
+      environment: ${{ env.VIX_ENVIRONMENT }}
+
       
     steps:
     
       - uses: actions/checkout@v3
 
-      - name: Set BUILD_NUMBER
-        uses: VixenLights/build-number@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      steps:
+      - name: create a custom version using run number offset by 1000 (run_number + 1000)
+        run: |
+          echo "BUILD_NUMBER=$((1000+GITHUB_RUN_NUMBER))" >> $GITHUB_ENV
 
       - name: Set variables
         shell: bash
@@ -50,19 +53,24 @@ jobs:
   
             echo "VIX_NOTES_FIX_VERSION=DevBuild" >> $GITHUB_ENV
             echo "VIX_NOTES_BUILD_TYPE=${1}.${2}u${3:-0}" >> $GITHUB_ENV
-            echo "VIX_PRE_RELEASE=false" >> $GITHUB_ENV
+            echo "VIX_ENVIRONMENT=Production" >> $GITHUB_ENV
             echo "VIX_RELEASE_TAG=${VIX_RELEASE_TAG}" >> $GITHUB_ENV
             echo "VIX_VERSION=${1}.${2}.${BUILD_NUMBER}.${3:-0}" >> $GITHUB_ENV
+            echo "VIX_APP_VERSION=${1}.${2}.${3}" >> $GITHUB_ENV
           else
             echo "VIX_NOTES_FIX_VERSION=DevBuild" >> $GITHUB_ENV
             echo "VIX_NOTES_BUILD_TYPE=Development" >> $GITHUB_ENV
-            echo "VIX_PRE_RELEASE=true" >> $GITHUB_ENV
-            echo "VIX_RELEASE_TAG=Testbuild-${BUILD_NUMBER}" >> $GITHUB_ENV
+            echo "VIX_ENVIRONMENT=Development" >> $GITHUB_ENV
+            echo "VIX_RELEASE_TAG=DevBuild-${BUILD_NUMBER}" >> $GITHUB_ENV
             echo "VIX_VERSION=0.0.${BUILD_NUMBER}.0" >> $GITHUB_ENV
+            echo "VIX_APP_VERSION=0.0.${BUILD_NUMBER}" >> $GITHUB_ENV
           fi
           
       - name: show github env
         run: echo "${GITHUB_ENV}"
+        
+      - name: show github run number
+        run: echo "${GITHUB_RUN_NUMBER}"
 
       - name: Update release notes
         run: ./Build/CreateReleaseNotes.ps1 -jiraUrl "http://bugs.vixenlights.com" -project "Vixen 3" -fixVersion "${env:VIX_NOTES_FIX_VERSION}" -buildType "${env:VIX_NOTES_BUILD_TYPE}"
@@ -95,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Download Release Notes artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: _releaseNotes
       
@@ -106,28 +114,12 @@ jobs:
         
       - uses: microsoft/setup-msbuild@v1.1
       
-      - name: Setup custom NSIS
-        id: setup-nsis
-        uses: VixenLights/makensis-action@bld01-v2.51
-        with:
-          just-include: true
-          include-more-plugins: true
-            
-      - name: Update versions
-        run: |
-          ./Build/dotnet-setversion/dotnet-setversion ${{ needs.setup.outputs.version }} Vixen.System\Vixen.csproj
-          ./Build/dotnet-setversion/dotnet-setversion ${{ needs.setup.outputs.version }} Application\VixenApplication\VixenApplication.csproj
-        
       - name: NuGet Restore
         run: nuget restore Vixen.sln
         
       - name: Build x86
-        run: msbuild Vixen.sln -m -t:Rebuild -p:Configuration=Release -p:Platform=x86
+        run: msbuild Vixen.sln -m -t:Rebuild -p:Configuration=Deploy -p:Platform=x86 -p:Environment:${{ needs.setup.outputs.environment }} -p:App_Version=${{ needs.setup.outputs.app_version }} -p:Assembly_Version=${{ needs.setup.outputs.version }}
   
-      - name: Build x86 installer
-        run: ${{ steps.setup-nsis.outputs.nsis-path }} /DBUILDARCH=32 Installer\Installer.nsi
-        shell: cmd
-      
       - run: dir
         shell: cmd
         
@@ -140,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: _setup32
-          path: ${{ env.SETUP_32 }}
+          path: Release\Setup\${{ needs.setup.outputs.environment }}\${{ env.SETUP_32 }}
 
 
   build_x64:
@@ -158,7 +150,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Download Release Notes artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: _releaseNotes
       
@@ -169,28 +161,12 @@ jobs:
         
       - uses: microsoft/setup-msbuild@v1.1
       
-      - name: Setup custom NSIS
-        id: setup-nsis
-        uses: VixenLights/makensis-action@bld01-v2.51
-        with:
-          just-include: true
-          include-more-plugins: true
-            
-      - name: Update versions
-        run: |
-          ./Build/dotnet-setversion/dotnet-setversion ${{ needs.setup.outputs.version }} Vixen.System\Vixen.csproj
-          ./Build/dotnet-setversion/dotnet-setversion ${{ needs.setup.outputs.version }} Application\VixenApplication\VixenApplication.csproj
-        
       - name: NuGet Restore
         run: nuget restore Vixen.sln
         
       - name: Build x64
-        run: msbuild Vixen.sln -m -t:Rebuild -p:Configuration=Release -p:Platform=x64
+        run: msbuild Vixen.sln -m -t:Rebuild -p:Configuration=Deploy -p:Platform=x64 -p:Environment:${{ needs.setup.outputs.environment }} -p:App_Version=${{ needs.setup.outputs.app_version }} -p:Assembly_Version=${{ needs.setup.outputs.version }}
   
-      - name: Build x64 installer
-        run: ${{ steps.setup-nsis.outputs.nsis-path }} /DBUILDARCH=64 Installer\Installer.nsi
-        shell: cmd
-      
       - run: dir
         shell: cmd
         
@@ -203,32 +179,34 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: _setup64
-          path: ${{ env.SETUP_64 }}
+          path: Release\Setup\${{ needs.setup.outputs.environment }}\${{ env.SETUP_64 }}
 
 
   create_release:
+  
+    if: github.repository == 'VixenLights/Vixen'
   
     needs:
       - setup
       - build_x86
       - build_x64
-    
+
     runs-on: windows-2019
 
     steps:
 
       - name: Download _setup32 artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: _setup32
       
       - name: Download _setup64 artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: _setup64
           
       - name: Download Build Release Notes Markdown artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: _releaseNotesMd
           
@@ -264,37 +242,3 @@ jobs:
           asset_name: ${{ needs.build_x64.outputs.setup_64 }}
           asset_content_type: application/vnd.microsoft.portable-executable
 
-      ###########################################
-      # Required secrets:
-      # SSH_KNOWN_HOSTS - output of "ssh-keyscan -p <port> <target_host>"
-      # SSH_PORT - sshd port on <target_host>
-      # SSH_PRIVATE_KEY - user's private key
-      # SSH_TARGET - <target_host>:/path/to/dir
-      # SSH_USER - username to login with
-      ###########################################
-      - name: Upload assets to vixenlights.com
-        shell: bash
-        run: |
-          if [[ -z "${{ secrets.SSH_TARGET }}" ]] ;then
-            exit 0
-          fi
-          
-          TARGET_EXTRA=
-          if [[ "${{ needs.setup.outputs.pre_release }}" = "false" ]] ;then
-            TARGET_EXTRA=/releases
-          fi
-          
-          mkdir -p ~/.ssh
-          touch ~/.ssh/id_rsa ~/.ssh/known_hosts
-          chmod 700 ~/.ssh
-          chmod 600 ~/.ssh/id_rsa ~/.ssh/known_hosts
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          scp \
-            -P ${{ secrets.SSH_PORT }} \
-            -o CheckHostIP=no \
-            -o StrictHostKeyChecking=yes \
-            -o NumberOfPasswordPrompts=0 \
-            _setup32/${{ needs.build_x86.outputs.setup_32 }} \
-            _setup64/${{ needs.build_x64.outputs.setup_64 }} \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_TARGET }}${TARGET_EXTRA}


### PR DESCRIPTION
* Switch to use Github run number for the build number. Will require calibrating the offset to line up with past builds.
* Remove NSIS steps since the setup will be created by the msbuild run.
* Refactor msbuild step to use the new options. Update the other variables in the setup to produce our desired results.
* Remove the asset upload to the the vixen lights build folder since we will just download from Github.