### PR TITLE
VIX-3419 Bump OS to Windows-2022

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -22,7 +22,7 @@ jobs:
   
     if: github.repository == 'VixenLights/Vixen' || github.repository == 'jeffu231/Vixen'
   
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     outputs:
       build_number: ${{ env.BUILD_NUMBER }}
@@ -97,7 +97,7 @@ jobs:
     outputs:
       setup_32: ${{ env.SETUP_32 }}
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     


### PR DESCRIPTION
* Need msbuild 17 which is in VS 2022 and part of windows-2022.